### PR TITLE
add simple staking contract and update configuration

### DIFF
--- a/Clarinet.toml
+++ b/Clarinet.toml
@@ -1,21 +1,19 @@
 [project]
-name = "Simple-Staking"
-description = ""
+name = 'Simple-Staking'
+description = ''
 authors = []
 telemetry = false
-cache_dir = "./.cache"
-
-# [contracts.counter]
-# path = "contracts/counter.clar"
-
+cache_dir = './.cache'
+requirements = []
+[contracts.simple-staking]
+path = 'contracts/simple-staking.clar'
+clarity_version = 2
+epoch = 2.5
 [repl.analysis]
-passes = ["check_checker"]
-check_checker = { trusted_sender = false, trusted_caller = false, callee_filter = false }
+passes = ['check_checker']
 
-# Check-checker settings:
-# trusted_sender: if true, inputs are trusted after tx_sender has been checked.
-# trusted_caller: if true, inputs are trusted after contract-caller has been checked.
-# callee_filter: if true, untrusted data may be passed into a private function without a
-# warning, if it gets checked inside. This check will also propagate up to the
-# caller.
-# More informations: https://www.hiro.so/blog/new-safety-checks-in-clarinet
+[repl.analysis.check_checker]
+strict = false
+trusted_sender = false
+trusted_caller = false
+callee_filter = false

--- a/contracts/simple-staking.clar
+++ b/contracts/simple-staking.clar
@@ -1,0 +1,143 @@
+;; title: simple-staking
+;; description: This is a simple staking smart contract where users can stake their NFT for FT rewards
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Cons, Vars and Maps ;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-constant profit-per-block u1)
+
+(define-map NFT-status uint {last-staked-height: uint, staker: principal})
+
+(define-map user-stakes principal (list 100 uint))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Read-only Funcs ;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-read-only (get-unclaimed-balance)
+    (let
+        (
+            (stakes (default-to (list ) (map-get? user-stakes tx-sender)))
+        )
+        (fold + (map get-height-difference stakes) u0)
+    )
+)
+
+(define-read-only (check-NFT-status (id uint))
+    (map-get? NFT-status id)
+)
+
+(define-read-only (get-user-stakes)
+    (map-get? user-stakes tx-sender)
+)
+
+(define-read-only (check-reward-rate)
+    (let
+        (
+            (stakes (default-to (list ) (map-get? user-stakes tx-sender)))
+        )
+        (* profit-per-block (len stakes))
+    )
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Public Functions ;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-public (stake-NFT (id uint))
+    (let
+        (   
+            (owner (unwrap! (contract-call? .simple-NFT get-owner id) (err "err-item-not-minted")))
+            (stakes (default-to (list ) (map-get? user-stakes tx-sender)))
+            (stake (map-get? NFT-status id))
+        )
+        (asserts! (is-eq (some tx-sender) owner) (err "err-tx-sender-not-item-owner"))
+        (asserts! (is-none stake) (err "err-item-already-staked"))
+        (unwrap! (contract-call? .simple-NFT transfer id tx-sender (as-contract tx-sender)) (err "err-transferring-NFT"))
+        (map-set NFT-status id {last-staked-height: block-height, staker: tx-sender})
+        (ok (map-set user-stakes tx-sender (unwrap! (as-max-len? (append stakes id) u100) (err "err-stake-overflow"))))
+    )
+)
+
+(define-public (unstake-NFT (id uint))
+    (let
+        (
+            (current-tx-sender tx-sender)
+            (owner (unwrap! (contract-call? .simple-NFT get-owner id) (err "err-item-not-minted")))
+            (stakes (default-to (list ) (map-get? user-stakes tx-sender)))
+            (stake (unwrap! (map-get? NFT-status id) (err "err-item-not-staked")))
+            (staker (get staker stake))
+            (reward (get-height-difference id))
+        )
+        (asserts! (is-eq staker tx-sender) (err "err-tx-sender-not-item-staker"))
+        (unwrap! (contract-call? .simple-NFT transfer id (as-contract tx-sender) tx-sender) (err "err-transferring-NFT"))
+        (unwrap! (contract-call? .simple-FT mint-stake-reward reward) (err "err-minting-reward"))
+        (map-delete NFT-status id)
+        (var-set temp-int id)
+        (ok (map-set user-stakes tx-sender (filter remove-uint stakes)))
+    )
+)
+
+(define-public (claim-one (id uint))
+    (let
+        (
+            (stake (unwrap! (map-get? NFT-status id) (err "err-item-not-staked")))
+            (staker (get staker stake))
+            (reward (get-height-difference id))
+        )
+        (asserts! (is-eq staker tx-sender) (err "err-tx-sender-not-item-staker"))
+        (unwrap! (contract-call? .simple-FT mint-stake-reward reward) (err "err-minting-reward"))
+        (ok (map-set NFT-status id 
+            (merge
+                stake
+                {last-staked-height: block-height}
+            )
+        ))
+    )
+)
+
+(define-public (claim-rewards)
+    (let
+        (
+            (stakes (default-to (list ) (map-get? user-stakes tx-sender)))
+            (rewards (get-unclaimed-balance ))
+        )
+        (unwrap! (contract-call? .simple-FT mint-stake-reward rewards) (err "err-minting-reward"))
+        (ok (map reset-stake stakes))
+    )
+)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;; Private Functions ;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define-data-var temp-int uint u0)
+
+(define-private (get-height-difference (stake-id uint))
+    (let
+        (
+            (stake-status (default-to {last-staked-height: block-height, staker: tx-sender} (map-get? NFT-status stake-id)))
+            (last-stake-height (get last-staked-height stake-status))
+        )
+        (- block-height last-stake-height)
+    )
+)
+
+(define-private (remove-uint (item uint))
+    (not (is-eq (var-get temp-int) item))
+)
+
+(define-private (reset-stake (stake-id uint))
+    (let
+        (
+            (stake (unwrap! (map-get? NFT-status stake-id) (err "err-item-not-staked")))
+        )
+        (ok (map-set NFT-status stake-id 
+            (merge
+                stake
+                {last-staked-height: block-height}
+            )
+        ))
+    )
+)

--- a/tests/simple-staking.test.ts
+++ b/tests/simple-staking.test.ts
@@ -1,0 +1,21 @@
+
+import { describe, expect, it } from "vitest";
+
+const accounts = simnet.getAccounts();
+const address1 = accounts.get("wallet_1")!;
+
+/*
+  The test below is an example. To learn more, read the testing documentation here:
+  https://docs.hiro.so/stacks/clarinet-js-sdk
+*/
+
+describe("example tests", () => {
+  it("ensures simnet is well initalised", () => {
+    expect(simnet.blockHeight).toBeDefined();
+  });
+
+  // it("shows an example", () => {
+  //   const { result } = simnet.callReadOnlyFn("counter", "get-counter", [], address1);
+  //   expect(result).toBeUint(0);
+  // });
+});


### PR DESCRIPTION
# Description

This PR introduces the Simple Staking Smart Contract, enabling users to stake NFTs in exchange for fungible token (FT) rewards. The contract interacts with external NFT and FT contracts to provide seamless staking functionality.

## Key Features

- **NFT Staking**: Users can stake their NFTs to earn FT rewards over time.
- **Reward Calculation**: Rewards are based on the number of blocks the NFT has been staked.
- **Claim Rewards**: Users can claim rewards for individual or all staked NFTs.
- **Unstaking Functionality**: Users can unstake NFTs and claim any pending rewards.
- **Read-Only Queries**: Functions to check staking status, reward rate, and unclaimed balances.

## Public Functions Added

- `stake-NFT`: Stake an NFT by its ID.
- `unstake-NFT`: Unstake an NFT and claim rewards.
- `claim-one`: Claim rewards for a specific NFT.
- `claim-rewards`: Claim all pending rewards for staked NFTs.

## Read-Only Functions Added

- `get-unclaimed-balance`: View total unclaimed rewards.
- `check-NFT-status`: Check the staking status of an NFT.
- `get-user-stakes`: Get a list of NFTs staked by the user.
- `check-reward-rate`: View the reward rate per block for the user.

## Private Helper Functions

- `get-height-difference`: Calculates block height difference for reward calculation.
- `remove-uint`: Filters and removes an item from a list.
- `reset-stake`: Resets the last-staked height for an NFT after claiming rewards.

## Linked Issues

- Implements staking mechanism for NFTs.
- Adds support for FT rewards based on staking duration.

## Future Enhancements

- Add support for variable reward rates.
- Integrate analytics for staked assets and earned rewards.